### PR TITLE
String handling optimizations

### DIFF
--- a/blkin-front.c
+++ b/blkin-front.c
@@ -38,24 +38,24 @@
 #include <fcntl.h>                                                              
                             
 /* Function pointers to be resolved during initialization */
-int (*blkin_init_new_trace)(struct blkin_trace *new_trace, char *name,
+int (*blkin_init_new_trace)(struct blkin_trace *new_trace, const char *name,
         struct blkin_endpoint *endpoint);
 
 int (*blkin_init_child)(struct blkin_trace *child, struct blkin_trace *parent,
-		struct blkin_endpoint *endpoint, char *child_name);
+		struct blkin_endpoint *endpoint, const char *child_name);
 
 int (*blkin_init_child_info)(struct blkin_trace *child,
         struct blkin_trace_info *info, struct blkin_endpoint *endpoint,
-	char *child_name);
+	const char *child_name);
 
-int (*blkin_init_endpoint)(struct blkin_endpoint * endp, char *ip,
-		int port, char *name);
+int (*blkin_init_endpoint)(struct blkin_endpoint * endp, const char *ip,
+		int port, const char *name);
 
 int (*blkin_init_string_annotation)(struct blkin_annotation *annotation,
-		char *key, char *val, struct blkin_endpoint * endpoint);
+		const char *key, const char *val, struct blkin_endpoint * endpoint);
 
 int (*blkin_init_timestamp_annotation)(struct blkin_annotation *annot,
-		char *event, struct blkin_endpoint * endpoint);
+		const char *event, struct blkin_endpoint * endpoint);
 
 int (*blkin_record)(struct blkin_trace *trace,
 		struct blkin_annotation *annotation);

--- a/blkin-front.h
+++ b/blkin-front.h
@@ -30,24 +30,24 @@
 #include <zipkin_c.h>
 
 /* Define extern function pointers to be resolved during initialization */
-extern int (*blkin_init_new_trace)(struct blkin_trace *new_trace, char *name,
+extern int (*blkin_init_new_trace)(struct blkin_trace *new_trace, const char *name,
         struct blkin_endpoint *endpoint);
 
 extern int (*blkin_init_child)(struct blkin_trace *child, struct blkin_trace *parent,
-		struct blkin_endpoint *endpoint, char *child_name);
+		struct blkin_endpoint *endpoint, const char *child_name);
 
 extern int (*blkin_init_child_info)(struct blkin_trace *child,
         struct blkin_trace_info *info, struct blkin_endpoint *endpoint,
-	char *child_name);
+	const char *child_name);
 
-extern int (*blkin_init_endpoint)(struct blkin_endpoint * endp, char *ip,
-		int port, char *name);
+extern int (*blkin_init_endpoint)(struct blkin_endpoint * endp, const char *ip,
+		int port, const char *name);
 
 extern int (*blkin_init_string_annotation)(struct blkin_annotation *annotation,
-		char *key, char *val, struct blkin_endpoint * endpoint);
+		const char *key, const char *val, struct blkin_endpoint * endpoint);
 
 extern int (*blkin_init_timestamp_annotation)(struct blkin_annotation *annot,
-		char *event, struct blkin_endpoint * endpoint);
+		const char *event, struct blkin_endpoint * endpoint);
 
 extern int (*blkin_record)(struct blkin_trace *trace,
 		struct blkin_annotation *annotation);

--- a/zipkin_c.c
+++ b/zipkin_c.c
@@ -48,7 +48,7 @@ int64_t random_big()
     return a;
 };
 
-int _blkin_init_new_trace(struct blkin_trace *new_trace, char *service,
+int _blkin_init_new_trace(struct blkin_trace *new_trace, const char *service,
         struct blkin_endpoint *endpoint)
 {
     int res;
@@ -69,7 +69,7 @@ OUT:
 
 int _blkin_init_child_info(struct blkin_trace *child,
         struct blkin_trace_info *parent_info, struct blkin_endpoint *endpoint,
-	char *child_name)
+	const char *child_name)
 {
     int res;
     if ((!child) || (!parent_info) || (!endpoint)){
@@ -88,7 +88,7 @@ OUT:
 }
 
 int _blkin_init_child(struct blkin_trace *child, struct blkin_trace *parent,
-		struct blkin_endpoint *endpoint, char *child_name)
+		struct blkin_endpoint *endpoint, const char *child_name)
 {
     int res;
     if (!parent) {
@@ -107,8 +107,8 @@ OUT:
     return res;
 }
 
-int _blkin_init_endpoint(struct blkin_endpoint *endp, char *ip, int port,
-        char *name)
+int _blkin_init_endpoint(struct blkin_endpoint *endp, const char *ip, int port,
+        const char *name)
 {
     int res;
     if (!endp){
@@ -127,8 +127,8 @@ OUT:
     return res;
 }
 
-int _blkin_init_string_annotation(struct blkin_annotation *annotation, char *key,
-        char *val, struct blkin_endpoint *endpoint)
+int _blkin_init_string_annotation(struct blkin_annotation *annotation, const char *key,
+        const char *val, struct blkin_endpoint *endpoint)
 {
     int res;
     if ((!annotation) || (!key) || (!val)){
@@ -146,7 +146,7 @@ OUT:
 }
 
 int _blkin_init_timestamp_annotation(struct blkin_annotation *annotation,
-        char *event, struct blkin_endpoint *endpoint)
+        const char *event, struct blkin_endpoint *endpoint)
 {
     int res;
     if ((!annotation) || (!event)){

--- a/zipkin_c.h
+++ b/zipkin_c.h
@@ -50,9 +50,9 @@
  * annotations take place
  */ 
 struct blkin_endpoint {
-    char *ip;
+    const char *ip;
     int port;
-    char *name;
+    const char *name;
 };
 
 /**
@@ -85,7 +85,7 @@ struct blkin_trace_info_packed {
  * Struct used to define the context in which an annotation happens
  */
 struct blkin_trace {
-    char *name;
+    const char *name;
     struct blkin_trace_info info;
     struct blkin_endpoint *trace_endpoint;
 };
@@ -106,8 +106,8 @@ typedef enum {
  */
 struct blkin_annotation {
     blkin_annotation_type type;
-    char *key;
-    char *val;
+    const char *key;
+    const char *val;
     struct blkin_endpoint *annotation_endpoint;
 };
 

--- a/zipkin_trace.h
+++ b/zipkin_trace.h
@@ -16,10 +16,10 @@
 TRACEPOINT_EVENT(
         zipkin,
         keyval,
-        TP_ARGS(char *, trace_name, char *, service, 
-            int, port, char *, ip, long, trace, 
+        TP_ARGS(const char *, trace_name, const char *, service, 
+            int, port, const char *, ip, long, trace, 
             long, span, long, parent_span, 
-            char *, key, char *, val ),
+            const char *, key, const char *, val ),
         
         TP_FIELDS(
                 /*
@@ -60,10 +60,10 @@ TRACEPOINT_LOGLEVEL(
 TRACEPOINT_EVENT(
         zipkin,
         timestamp,
-        TP_ARGS(char *, trace_name, char *, service, 
-            int, port, char *, ip, long, trace, 
+        TP_ARGS(const char *, trace_name, const char *, service, 
+            int, port, const char *, ip, long, trace, 
             long, span, long, parent_span, 
-            char *, event),
+            const char *, event),
         
         TP_FIELDS(
                 ctf_string(trace_name, trace_name)

--- a/ztracer.cc
+++ b/ztracer.cc
@@ -36,7 +36,7 @@ namespace ZTracer {
 		return blkin_init();
 	}
 
-	char * to_cstr(string &s)
+	char * to_cstr(const string &s)
 	{
 		char *cstr = new char [s.length()+1];
 		strcpy(cstr, s.c_str());
@@ -51,58 +51,58 @@ namespace ZTracer {
 
 		return to_cstr(s);
 	}
-	int ZTrace::keyval(string key, string val)
+	int ZTrace::keyval(const string &key, const string &val)
 	{
 		BLKIN_KEYVAL(&trace, ep->get_blkin_ep(), (char *)key.c_str(),
 				(char *)val.c_str());
 		return 0;
 	}
 
-	int ZTrace::event(string event)
+	int ZTrace::event(const string &event)
 	{
 		BLKIN_TIMESTAMP(&trace, ep->get_blkin_ep(), (char *)event.c_str());
 		return 0;
 	}
 
-	int ZTrace::keyval(string key, string val, ZTraceEndpointRef ep)
+	int ZTrace::keyval(const string &key, const string &val, ZTraceEndpointRef ep)
 	{
 		BLKIN_KEYVAL(&trace, ep->get_blkin_ep(), (char *)key.c_str(),
 				(char *)val.c_str());
 		return 0;
 	}
 
-	int ZTrace::event(string event, ZTraceEndpointRef ep)
+	int ZTrace::event(const string &event, ZTraceEndpointRef ep)
 	{
 		BLKIN_TIMESTAMP(&trace, ep->get_blkin_ep(), (char *)event.c_str());
 		return 0;
 	}
 
 
-	ZTraceEndpointRef create_ZTraceEndpoint(string ip, int port, string name)
+	ZTraceEndpointRef create_ZTraceEndpoint(const string &ip, int port, const string &name)
 	{
 		boost::shared_ptr<ZTraceEndpoint> ret(new ZTraceEndpoint(ip, port, name));
 		return ret;
 	}
 
-	ZTraceRef create_ZTrace(string name, ZTraceEndpointRef ep)
+	ZTraceRef create_ZTrace(const string &name, ZTraceEndpointRef ep)
 	{
 		boost::shared_ptr<ZTrace> ret(new ZTrace(name, ep));
 		return ret;
 	}
 
-	ZTraceRef create_ZTrace(string name, ZTraceRef t)
+	ZTraceRef create_ZTrace(const string &name, ZTraceRef t)
 	{
 		boost::shared_ptr<ZTrace> ret(new ZTrace(name, t));
 		return ret;
 	}
 
-	ZTraceRef create_ZTrace(string name, ZTraceRef t, ZTraceEndpointRef ep)
+	ZTraceRef create_ZTrace(const string &name, ZTraceRef t, ZTraceEndpointRef ep)
 	{
 		boost::shared_ptr<ZTrace> ret(new ZTrace(name, t, ep));
 		return ret;
 	}
 
-	ZTraceRef create_ZTrace(string name, ZTraceEndpointRef ep, struct blkin_trace_info *info, bool child)
+	ZTraceRef create_ZTrace(const string &name, ZTraceEndpointRef ep, struct blkin_trace_info *info, bool child)
 	{
 		boost::shared_ptr<ZTrace> ret(new ZTrace(name, ep, info, child));
 		return ret;

--- a/ztracer.cc
+++ b/ztracer.cc
@@ -36,29 +36,27 @@ namespace ZTracer {
 		return blkin_init();
 	}
 
-	int ZTrace::keyval(const string &key, const string &val)
+	int ZTrace::keyval(const char *key, const char *val)
 	{
-		BLKIN_KEYVAL(&trace, ep->get_blkin_ep(), (char *)key.c_str(),
-				(char *)val.c_str());
+		BLKIN_KEYVAL(&trace, ep->get_blkin_ep(), key, val);
 		return 0;
 	}
 
-	int ZTrace::event(const string &event)
+	int ZTrace::event(const char *event)
 	{
-		BLKIN_TIMESTAMP(&trace, ep->get_blkin_ep(), (char *)event.c_str());
+		BLKIN_TIMESTAMP(&trace, ep->get_blkin_ep(), event);
 		return 0;
 	}
 
-	int ZTrace::keyval(const string &key, const string &val, ZTraceEndpointRef ep)
+	int ZTrace::keyval(const char *key, const char *val, ZTraceEndpointRef ep)
 	{
-		BLKIN_KEYVAL(&trace, ep->get_blkin_ep(), (char *)key.c_str(),
-				(char *)val.c_str());
+		BLKIN_KEYVAL(&trace, ep->get_blkin_ep(), key, val);
 		return 0;
 	}
 
-	int ZTrace::event(const string &event, ZTraceEndpointRef ep)
+	int ZTrace::event(const char *event, ZTraceEndpointRef ep)
 	{
-		BLKIN_TIMESTAMP(&trace, ep->get_blkin_ep(), (char *)event.c_str());
+		BLKIN_TIMESTAMP(&trace, ep->get_blkin_ep(), event);
 		return 0;
 	}
 

--- a/ztracer.cc
+++ b/ztracer.cc
@@ -36,21 +36,6 @@ namespace ZTracer {
 		return blkin_init();
 	}
 
-	char * to_cstr(const string &s)
-	{
-		char *cstr = new char [s.length()+1];
-		strcpy(cstr, s.c_str());
-
-		return cstr;
-	}
-
-	char * ostr_to_cstr(ostringstream &stream)
-	{
-		string s;
-		s = stream.str();
-
-		return to_cstr(s);
-	}
 	int ZTrace::keyval(const string &key, const string &val)
 	{
 		BLKIN_KEYVAL(&trace, ep->get_blkin_ep(), (char *)key.c_str(),

--- a/ztracer.hpp
+++ b/ztracer.hpp
@@ -43,7 +43,7 @@ using std::ostringstream;
 
 namespace ZTracer {
 	int ztrace_init(void);
-	char * to_cstr(string &s);
+	char * to_cstr(const string &s);
 	char * ostr_to_cstr(ostringstream &stream);
 
 	class ZTraceEndpoint;
@@ -64,7 +64,7 @@ namespace ZTracer {
 			}
 			friend ZTrace;
 		public:
-			ZTraceEndpoint(string ip, int port, string endpoint_name)
+			ZTraceEndpoint(const string &ip, int port, const string &endpoint_name)
 			{
 				c_ip = to_cstr(ip);
 				c_name = to_cstr(endpoint_name);
@@ -91,21 +91,21 @@ namespace ZTracer {
 				return &trace;
 			}
 		public:
-			ZTrace(string name, ZTraceEndpointRef ep)
+			ZTrace(const string &name, ZTraceEndpointRef ep)
 				:ep(ep)
 			{
 				c_name = to_cstr(name);
 				blkin_init_new_trace(&trace, c_name, ep->get_blkin_ep());
 			}
 
-			ZTrace(string name, ZTraceRef t)
+			ZTrace(const string &name, ZTraceRef t)
 			{
 				this->ep = t->ep;
 				c_name = to_cstr(name);
 				blkin_init_child(&trace, t->get_blkin_trace(), ep->get_blkin_ep(), c_name);
 			}
 
-			ZTrace(string name, ZTraceRef t, ZTraceEndpointRef ep)
+			ZTrace(const string &name, ZTraceRef t, ZTraceEndpointRef ep)
 			{
 				this->ep = ep;
 				c_name = to_cstr(name);
@@ -113,7 +113,7 @@ namespace ZTracer {
 						c_name);
 			}
 
-			ZTrace(string name, ZTraceEndpointRef ep, struct blkin_trace_info *info, bool child=false)
+			ZTrace(const string &name, ZTraceEndpointRef ep, struct blkin_trace_info *info, bool child=false)
 			{
 				c_name = to_cstr(name);
 				this->ep = ep;
@@ -137,17 +137,17 @@ namespace ZTracer {
 
 			int get_trace_info(struct blkin_trace_info *info);
 			int set_trace_info(struct blkin_trace_info *info);
-			int keyval(string key, string val);
-			int keyval(string key, string val, ZTraceEndpointRef ep);
-			int event(string event);
-			int event(string event, ZTraceEndpointRef ep);
+			int keyval(const string &key, const string &val);
+			int keyval(const string &key, const string &val, ZTraceEndpointRef ep);
+			int event(const string &event);
+			int event(const string &event, ZTraceEndpointRef ep);
 	};
 
-	ZTraceEndpointRef create_ZTraceEndpoint(string ip, int port, string name);
-	ZTraceRef create_ZTrace(string name, ZTraceEndpointRef ep);
-	ZTraceRef create_ZTrace(string name, ZTraceRef t);
-	ZTraceRef create_ZTrace(string name, ZTraceRef t, ZTraceEndpointRef ep);
-	ZTraceRef create_ZTrace(string name, ZTraceEndpointRef ep, struct blkin_trace_info *info, bool child=false);
+	ZTraceEndpointRef create_ZTraceEndpoint(const string &ip, int port, const string &name);
+	ZTraceRef create_ZTrace(const string &name, ZTraceEndpointRef ep);
+	ZTraceRef create_ZTrace(const string &name, ZTraceRef t);
+	ZTraceRef create_ZTrace(const string &name, ZTraceRef t, ZTraceEndpointRef ep);
+	ZTraceRef create_ZTrace(const string &name, ZTraceEndpointRef ep, struct blkin_trace_info *info, bool child=false);
 
 }
 #endif /* end of include guard: ZTRACER_H */

--- a/ztracer.hpp
+++ b/ztracer.hpp
@@ -38,13 +38,10 @@ extern "C" {
 #include <blkin-front.h>
 }
 
-using std::string;
-using std::ostringstream;
-
 namespace ZTracer {
+	using std::string;
+
 	int ztrace_init(void);
-	char * to_cstr(const string &s);
-	char * ostr_to_cstr(ostringstream &stream);
 
 	class ZTraceEndpoint;
 	class ZTrace;
@@ -55,9 +52,9 @@ namespace ZTracer {
 	class ZTraceEndpoint {
 		private:
 			struct blkin_endpoint ep;
-			char *c_ip;
-			char *c_name;
-		protected:
+			string ip;
+			string name;
+
 			struct blkin_endpoint * get_blkin_ep()
 			{
 				return &ep;
@@ -65,18 +62,13 @@ namespace ZTracer {
 			friend ZTrace;
 		public:
 			ZTraceEndpoint(const string &ip, int port, const string &endpoint_name)
+				: ip(ip), name(endpoint_name)
 			{
-				c_ip = to_cstr(ip);
-				c_name = to_cstr(endpoint_name);
-				blkin_init_endpoint(&ep, c_ip, port, c_name);
+				blkin_init_endpoint(&ep, ip.c_str(), port, name.c_str());
 			}
 			~ZTraceEndpoint()
 			{
 				//cout << "Endpoint destroyed" << std::endl;
-				if (c_ip)
-					delete [] c_ip;
-				if (c_name)
-					delete [] c_name;
 			}
 	};
 
@@ -84,52 +76,44 @@ namespace ZTracer {
 		private:
 			struct blkin_trace trace;
 			ZTraceEndpointRef ep;
-			char *c_name = NULL;
-		protected:
+			string name;
+
 			struct blkin_trace *get_blkin_trace()
 			{
 				return &trace;
 			}
 		public:
 			ZTrace(const string &name, ZTraceEndpointRef ep)
-				:ep(ep)
+				: ep(ep), name(name)
 			{
-				c_name = to_cstr(name);
-				blkin_init_new_trace(&trace, c_name, ep->get_blkin_ep());
+				blkin_init_new_trace(&trace, name.c_str(), ep->get_blkin_ep());
 			}
 
 			ZTrace(const string &name, ZTraceRef t)
+				: ep(t->ep), name(name)
 			{
-				this->ep = t->ep;
-				c_name = to_cstr(name);
-				blkin_init_child(&trace, t->get_blkin_trace(), ep->get_blkin_ep(), c_name);
+				blkin_init_child(&trace, t->get_blkin_trace(),
+						ep->get_blkin_ep(), name.c_str());
 			}
 
 			ZTrace(const string &name, ZTraceRef t, ZTraceEndpointRef ep)
+				: ep(ep), name(name)
 			{
-				this->ep = ep;
-				c_name = to_cstr(name);
 				blkin_init_child(&trace, t->get_blkin_trace(), ep->get_blkin_ep(),
-						c_name);
+						name.c_str());
 			}
 
 			ZTrace(const string &name, ZTraceEndpointRef ep, struct blkin_trace_info *info, bool child=false)
+				: ep(ep), name(name)
 			{
-				c_name = to_cstr(name);
-				this->ep = ep;
 				if (child)
-					blkin_init_child_info(&trace, info, ep->get_blkin_ep(), c_name);
+					blkin_init_child_info(&trace, info, ep->get_blkin_ep(), name.c_str());
 				else {
-					blkin_init_new_trace(&trace, c_name, ep->get_blkin_ep());
+					blkin_init_new_trace(&trace, name.c_str(), ep->get_blkin_ep());
 					blkin_set_trace_info(&trace, info);
 				}
 			}
-			~ZTrace()
-			{
-				if (c_name) {
-					delete [] c_name;
-				}
-			}
+
             ZTraceEndpointRef get_endpoint()
             {
                 return this->ep;

--- a/ztracer.hpp
+++ b/ztracer.hpp
@@ -121,10 +121,10 @@ namespace ZTracer {
 
 			int get_trace_info(struct blkin_trace_info *info);
 			int set_trace_info(struct blkin_trace_info *info);
-			int keyval(const string &key, const string &val);
-			int keyval(const string &key, const string &val, ZTraceEndpointRef ep);
-			int event(const string &event);
-			int event(const string &event, ZTraceEndpointRef ep);
+			int keyval(const char *key, const char *val);
+			int keyval(const char *key, const char *val, ZTraceEndpointRef ep);
+			int event(const char *event);
+			int event(const char *event, ZTraceEndpointRef ep);
 	};
 
 	ZTraceEndpointRef create_ZTraceEndpoint(const string &ip, int port, const string &name);


### PR DESCRIPTION
Recommended optimizations for the c++ interface:
1. Take std::string arguments by const reference to avoid the copies associated with pass-by-value.
2. Store strings as std::string instead of allocating and copying into a raw string. If the string is short, the standard library will avoid heap allocation altogether (see Small String Optimization).

The first patch converts the c interface to use const char\* so they can accept std::string::c_str().
